### PR TITLE
Testing/style fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<p align="center">
+<a href="https://travis-ci.org/molssi-sss/"> <img src="https://travis-ci.org/molssi-sss/QM_2017_SSS_Team2.svg?branch=master" /></a>
+<a href="https://codecov.io/gh/molssi-sss/QM_2017_SSS_Team2">
+<img src="https://codecov.io/gh/molssi-sss/QM_2017_SS_Team2/branch/master/graph/badge.svg" /></a>
+</p>
+
 # QM_2017_SSS_Team2
 
 by Andrew M. James (AJ), Kirk Pearce, Alan Rask, Brad Welch

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<a href="https://travis-ci.org/molssi-sss/"> <img src="https://travis-ci.org/molssi-sss/QM_2017_SSS_Team2.svg?branch=master" /></a>
+<a href="https://travis-ci.org/molssi-sss/QM_2017_SSS_Team2"> <img src="https://travis-ci.org/molssi-sss/QM_2017_SSS_Team2.svg?branch=master" /></a>
 <a href="https://codecov.io/gh/molssi-sss/QM_2017_SSS_Team2">
 <img src="https://codecov.io/gh/molssi-sss/QM_2017_SS_Team2/branch/master/graph/badge.svg" /></a>
 </p>

--- a/qm2/__init__.py
+++ b/qm2/__init__.py
@@ -3,6 +3,6 @@ This is the base file of QM2.
 """
 
 from . import math
-from .math import add #from the math in this folder, I want to import add
-from .math import mult #from the math in this folder, I want to import mult
+from .math import add  # from the math in this folder, I want to import add
+from .math import mult  # from the math in this folder, I want to import mult
 from .math import greater

--- a/qm2/math.py
+++ b/qm2/math.py
@@ -1,6 +1,7 @@
 """
-A small set of functions for doing math operations. 
+A small set of functions for doing math operations.
 """
+
 
 def add(a, b):
     """
@@ -8,11 +9,13 @@ def add(a, b):
     """
     return a + b
 
+
 def mult(a, b):
     """
     Multiplication between two arguments
     """
     return a * b
+
 
 def greater(a, b):
     """
@@ -24,4 +27,4 @@ def greater(a, b):
         return b
     else:
         print('Something weird happened')
-        return 0 
+        return 0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
         version="0.1.1",
         description='MolSSI Software Summer School 2017 Quantum Mechanics Group 2 Repo',
         author='QM Team 2',
-        url="https://github.com/MolSSI-SSS/QM_2017_SSS_Team2"
+        url="https://github.com/MolSSI-SSS/QM_2017_SSS_Team2",
         license='BSD-3C',
         packages=setuptools.find_packages(),
         install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,13 @@ if __name__ == "__main__":
     setuptools.setup(
         name='qm2',
         version="0.1.1",
-        description='MolSSI Software Summer School 2017 Quantum Mechanics Group 2 Repo',
+        description='MolSSI Software Summer School 2017 \
+                Quantum Mechanics Group 2 Repo',
         author='QM Team 2',
         url="https://github.com/MolSSI-SSS/QM_2017_SSS_Team2",
         license='BSD-3C',
         packages=setuptools.find_packages(),
-        install_requires=[
-            'numpy>=1.7',
-        ],
+        install_requires=['numpy>=1.7', ],
         extras_require={
             'docs': [
                 'sphinx==1.2.3',  # autodoc was broken in 1.3.1
@@ -26,18 +25,15 @@ if __name__ == "__main__":
                 'tox',
             ],
         },
-
         tests_require=[
             'pytest',
             'pytest-cov',
             'pytest-pep8',
             'tox',
         ],
-
         classifiers=[
             'Development Status :: 4 - Beta',
             'Intended Audience :: Science/Research',
             'Programming Language :: Python :: 3',
         ],
-        zip_safe=True,
-    )
+        zip_safe=True, )

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -2,19 +2,46 @@
 Testing for the math.py module.
 """
 
-import qm2 #runs a test on the qm2 in the same directory as tests/
+import qm2  # runs a test on the qm2 in the same directory as tests/
 import pytest
 
-def test_add():
-    assert qm2.math.add(5, 2) == 7
-    assert qm2.math.add(2, 5) == 7
+test_add_data = [
+    (2, 5, 7),
+    (1, 2, 3),
+    (11, 9, 20),
+    (11, 0, 11),
+    (0, 0, 0),
+]
 
-def test_mult():
-    assert qm2.math.mult(5, 2) == 10
-    assert qm2.math.mult(2, 5) == 10
+test_mult_data = [
+    (2, 5, 10),
+    (1, 2, 2),
+    (11, 9, 99),
+    (11, 0, 0),
+    (0, 0, 0),
+]
+test_greater_data = [
+    (2, 5, 5),
+    (1, 2, 2),
+    (11, 9, 11),
+    (11, 0, 11),
+    (0, 0, 0),
+]
 
-def test_greater():
-    assert qm2.math.greater(5, 2) == 5
-    assert qm2.math.greater(2, 5) == 5
-    assert qm2.math.greater(5, 5) == 5
 
+@pytest.mark.parametrize("a,b,expected", test_add_data)
+def test_add(a, b, expected):
+    assert qm2.math.add(a, b) == expected
+    assert qm2.math.add(b, a) == expected
+
+
+@pytest.mark.parametrize("a,b,expected", test_mult_data)
+def test_mult(a, b, expected):
+    assert qm2.math.mult(a, b) == expected
+    assert qm2.math.mult(b, a) == expected
+
+
+@pytest.mark.parametrize("a,b,expected", test_greater_data)
+def test_greater(a, b, expected):
+    assert qm2.math.greater(a, b) == expected
+    assert qm2.math.greater(b, a) == expected


### PR DESCRIPTION
# Key points

## Travis failing before running tests
- There was a small syntax error in `setup.py` that was causing travis to error out when the module was installed. The build/install should work fine now and the tests should run property.

## More Robust Testing
- adds the use of the `@pytest.mark.parametrize` decorator to automate multiple inputs
- adds a check to each test that the correct result is returned with transposed args

## Style changes
 - I used [yapf](https://github.com/google/yapf) to auto format all of the python code in the repo
 - I also ran everything through `pep8` and fixed a few additional violations by hand

# Notes/Questions:
 -  I use a vim plugin to auto-format code using yapf. If you are interested I can show you how to set that up. 
- We should use something like I have below to signal everyone when a PR is ready for review, and when it is still a work in progress 
  - [ ] Ready to go  `<---` Unchecked. Not ready to merge yet
    - feel free to look it over and give feedback, *just don't merge*. I'm still working on some more things for this PR
  - [x] Ready to go  `<---` Checked. Now I'm done working, once reviewed + approved this can be merged!

# Ready to go 
  - [x] Ready to go